### PR TITLE
fixed bug when count repos for --nickname invalid

### DIFF
--- a/gitcolombo.py
+++ b/gitcolombo.py
@@ -335,8 +335,8 @@ def main():
     if args.nickname:
         repos_count = get_public_repos_count(args.nickname)
         if repos_count:
-            print('found ', repos_count, ' repos')
-            repos += get_github_repos(args.nickname, repos_count)
+            print('found', repos_count, 'repos')
+            repos += get_github_repos(args.nickname, repos_count=repos_count)
 
     for repo in repos:
         analyst.append(source=repo)


### PR DESCRIPTION
found issue when tryed to analyze someone github repo by nickname. it's because of api.github.com/{}/repos by default has limits by count of repos. also don't saw any difference between users and orgs in this case